### PR TITLE
renaming

### DIFF
--- a/index.html
+++ b/index.html
@@ -34,7 +34,7 @@
       {
         "@context": "https://schema.org",
         "@type": "SoftwareApplication",
-        "name": "focusStation",
+        "name": "focusHub",
         "operatingSystem": "Windows","MacOS","Linux","Android","iOS",
         "applicationCategory": "Productivity",
         "applicationSubCategory": "Pomodoro Timer",

--- a/src/components/Timer/Timer.tsx
+++ b/src/components/Timer/Timer.tsx
@@ -120,11 +120,11 @@ export const Timer = () => {
     if (hasStarted) {
       const icon = sessionType === "Session" ? "⏱" : "☕️";
       // @ts-ignore
-      document.title = `FocusStation ${icon}${formatDisplayTime(parseInt(timerMinutes))}:${formatDisplayTime(
+      document.title = `FocusHub ${icon}${formatDisplayTime(parseInt(timerMinutes))}:${formatDisplayTime(
         parseInt(timerSeconds)
       )}`;
     } else {
-      document.title = "FocusStation";
+      document.title = "FocusHub";
     }
   }, [hasStarted, timerMinutes, timerSeconds, sessionType]);
 
@@ -182,8 +182,8 @@ export const Timer = () => {
     <div
       className={clsx(
         "dwidth sm:w-96 mb-2 max-w-sm rounded-lg border shadow-card transition-all duration-200",
-        breakStarted 
-          ? "bg-blue-50 border-info shadow-card-hover dark:bg-blue-900/30" 
+        breakStarted
+          ? "bg-blue-50 border-info shadow-card-hover dark:bg-blue-900/30"
           : "bg-background-primary border-border-light",
         "backdrop-blur-sm"
       )}


### PR DESCRIPTION
This pull request updates the branding of the application from "FocusStation" to "FocusHub" across the codebase. The most important changes include updates to the application metadata and the document title logic in the timer component.

Branding updates:

* [`index.html`](diffhunk://#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051L37-R37): Changed the `"name"` field in the application metadata from `"FocusStation"` to `"FocusHub"`.
* [`src/components/Timer/Timer.tsx`](diffhunk://#diff-84fa81a62d9764b3858c8b3a69ed1bb66e92647bbe4ddaec28172ede47f80e9bL123-R127): Updated the document title logic to reflect the new branding, changing occurrences of `"FocusStation"` to `"FocusHub"`.